### PR TITLE
Fix lyric scraping issue.

### DIFF
--- a/render/plugins/MusicMatch.ts
+++ b/render/plugins/MusicMatch.ts
@@ -2,7 +2,7 @@ import {SearchLyrics} from "./SearchLyrics";
 
 export class MusicMatch extends SearchLyrics {
     public search(title: string, artist: string, cb: (error?: any, lyrics?: string) => void) {
-        let url = `https://www.musixmatch.com/search/${encodeURIComponent(artist)} ${encodeURIComponent(title)}`;
+        let url = `https://www.musixmatch.com/search/${encodeURIComponent(artist)} ${encodeURIComponent(title)}/tracks`;
         this.doReq(url, (err, res, body) => {
             if (err || res.statusCode != 200) {
                 return cb('Error response searching music match');


### PR DESCRIPTION
As it stands now, the scraping program grabs the first song that shows up on the results -- which sometimes results in a song with the title being part of the lyrics, rather than searching solely in the name of the track for the title. (For an example, try searching "Two Door Cinema Club Next Year", it results in the song "What You Know" by 2DCC, which has the words "Next Year" in it.) This issue is simply rectified by adding "/tracks" to the end of the search URL, as it then searches for tracks with that name, solving the issue altogether.

tl;dr this fixes an issue where lyricfier grabs the wrong lyrics altogether.