### PR TITLE
Displaying data immediately upon reciept

### DIFF
--- a/render/Searcher.ts
+++ b/render/Searcher.ts
@@ -1,67 +1,15 @@
 import {SearchLyrics} from './plugins/SearchLyrics';
 import {SearchWikia} from "./plugins/SearchWikia";
 import {MusicMatch} from "./plugins/MusicMatch";
-import {SpotifyService} from './SpotifyService';
 const async = require('async');
 const plugins = [MusicMatch, SearchWikia];
 const request = require('request').defaults({timeout: 5000});
 
 export class Searcher {
-
-    protected service:SpotifyService;
-    protected lastSongSync = {};
     protected plugins:SearchLyrics[];
-    protected notifier;
 
-    constructor(notifier) {
-        this.notifier = notifier;
+    constructor() {
         this.loadPlugins();
-    }
-
-
-    saveLastSong(song) {
-        for (let k of Object.keys(song)) {
-            this.lastSongSync[k] = song[k];
-        }
-    }
-
-    sendStatus(msg) {
-        this.notifier(msg);
-    }
-
-    syncLyrics(cb) {
-        console.log('sync lyrics called');
-        this.getSpotify().getCurrentSong((err, song) => {
-            if (err) {
-                this.sendStatus('Current song error: ' + err);
-                return cb(true);
-            }
-            if (this.isLastSong(song)) {
-                console.log('is last song nothing to do here');
-                return cb(null, this.lastSongSync, false);
-            }
-            console.log('is not last song searching by title and artist');
-            this.sendStatus('Current song: ' + song.title);
-            this.search(song.title, song.artist, (err, lyric) => {
-                if (err) {
-                    this.sendStatus('Plugin error: ' + err);
-                    return;
-                }
-                this.sendStatus('Song result!');
-                song.lyric = lyric;
-                this.saveLastSong(song);
-                cb(null, song, true);
-            });
-        });
-    }
-
-    isLastSong(song) {
-        for (let k of ['artist', 'title']) {
-            if (song[k] !== this.lastSongSync[k]) {
-                return false;
-            }
-        }
-        return true;
     }
 
     loadPlugins() {
@@ -86,12 +34,4 @@ export class Searcher {
             cb(err, lyric);
         });
     }
-
-    getSpotify() {
-        if (!this.service) {
-            this.service = new SpotifyService();
-        }
-        return this.service;
-    }
-
 }

--- a/render/SongRender.ts
+++ b/render/SongRender.ts
@@ -1,6 +1,7 @@
 import Component from 'vue-class-component';
 import {Searcher} from "./Searcher";
 import {template} from './template';
+import {SpotifyService} from './SpotifyService';
 
 @Component({
     props: {
@@ -15,6 +16,8 @@ import {template} from './template';
 })
 
 export class SongRender {
+    protected lastSongSync;
+    protected service:SpotifyService;
     protected song;
     protected shell;
     protected searcher: Searcher;
@@ -25,7 +28,8 @@ export class SongRender {
     data() {
         return {
             song: null,
-            searcher: new Searcher(this.notifyStatus),
+            lastSongSync: {},
+            searcher: new Searcher(),
             nextCallTime: 5000
         }
     }
@@ -49,15 +53,67 @@ export class SongRender {
     }
 
     refresh() {
-        this.searcher.syncLyrics((error, song, changed) => {
-            if (!error && changed) {
-                this.song = song;
-                this['$nextTick'](() => {
-                    document.getElementById("lyricBox").scrollTop = 0;
-                })
+        console.log('refreshing');
+        this.getSpotify().getCurrentSong((err, song) => {
+            if (err) {
+                this.notifyStatus('Current song error: ' + err);
+                this.scheduleNextCall();
+            } else if (this.isLastSong(song)) {
+                console.log('is last song nothing to do here');
+                this.scheduleNextCall();
+            } else {
+                console.log('is not last song searching by title and artist');
+                song.lyric = 'Loading Lyrics...';
+                this.displaySong(song);
+                this.saveLastSong(song);
+                this.searcher.search(song.title, song.artist, (err, lyric) => {
+                    if (err) {
+                        this.notifyStatus('Plugin error: ' + err);
+                        return;
+                    }
+                    if (lyric === null) {
+                      song.lyric = 'Sorry, couldn\'t find lyrics for this song!';
+                    } else {
+                      song.lyric = lyric;
+                    }
+                    this.displaySong(song);
+                    this['$nextTick'](() => {
+                        document.getElementById("lyricBox").scrollTop = 0;
+                    });
+                    this.scheduleNextCall();
+                });
             }
-            this.scheduleNextCall();
         });
+    }
+
+    displaySong(song) {
+      const newSongObject = {};
+      for (let k of Object.keys(song)) {
+          newSongObject[k] = song[k];
+      }
+      this.song = newSongObject;
+    }
+
+    isLastSong(song) {
+        for (let k of ['artist', 'title']) {
+            if (song[k] !== this.lastSongSync[k]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    saveLastSong(song) {
+        for (let k of Object.keys(song)) {
+            this.lastSongSync[k] = song[k];
+        }
+    }
+
+    getSpotify() {
+        if (!this.service) {
+            this.service = new SpotifyService();
+        }
+        return this.service;
     }
 
     openExternal(url) {


### PR DESCRIPTION
Rather than using toasts to communicate the stages of detecting a new song and searching for and loading lyrics, this pr moves functionality from Searcher to SongRenderer in order to display the new artist/song/album artwork upon detecting a new song, displaying a loading message in place of the lyrics, then either displaying the fetched lyrics or a message explaining that we couldn't find any lyrics for that song.