### PR TITLE
Rename file links within `tsconfig.json` to stop compiler errors.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,11 +6,11 @@
     "experimentalDecorators": true
   },
   "files": [
-    "gulpfile",
-    "main",
-    "Lyricfier",
-    "render/plugins/SearchLyrics",
-    "render/plugins/SearchWikia",
+    "gulpfile.ts",
+    "main.ts",
+    "Lyricfier.ts",
+    "render/plugins/SearchLyrics.ts",
+    "render/plugins/SearchWikia.ts",
     "render/Searcher.ts",
     "render/NormalizeTitles.ts",
     "render/LyricfierRender.ts",


### PR DESCRIPTION
Typescript compiler throwing errors on missing files (though still builds successfully).